### PR TITLE
Add unit tests for CRUDGrain

### DIFF
--- a/test/RayWorkflow.Orleans.Test/Crud/CrudGrainTests.cs
+++ b/test/RayWorkflow.Orleans.Test/Crud/CrudGrainTests.cs
@@ -1,4 +1,4 @@
-﻿using RayWorkflow.Domain.Shared.Workflow;
+using RayWorkflow.Domain.Shared.Workflow;
 using RayWorkflow.Domain.Workflow;
 using RayWorkflow.IGrains;
 using Shouldly;
@@ -79,6 +79,54 @@ namespace RayWorkflow.Orleans.Test.Crud
             UsingDbContext(dbContext =>
             {
                 dbContext.Set<WorkflowForm>().Any(x => x.Id == entity.Id).ShouldBeFalse();
+            });
+        }
+
+        [Fact]
+        public async Task CanCreateReadUpdateDelete()
+        {
+            var id = Guid.NewGuid();
+            var grain = ClusterClient.GetGrain<IWorkflowFormGrain<WorkflowFormDto>>(id);
+
+            // Create
+            var createDto = new WorkflowFormDto { Id = id, Name = "CreateTest", Sort = 1 };
+            await grain.Create(createDto);
+            var createResult = await grain.Get();
+            createResult.Name.ShouldBe(createDto.Name);
+            await Task.Delay(500);
+            UsingDbContext(dbContext =>
+            {
+                dbContext.Set<WorkflowForm>().Any(x => x.Id == id).ShouldBeTrue();
+                var workflowForm = dbContext.Set<WorkflowForm>().First(x => x.Id == id);
+                workflowForm.Name.ShouldBe(createDto.Name);
+            });
+
+            // Read
+            var readResult = await grain.Get();
+            readResult.Name.ShouldBe(createDto.Name);
+
+            // Update
+            var updateDto = new WorkflowFormDto { Id = id, Name = "UpdateTest", Sort = 2 };
+            await grain.Update(updateDto);
+            var updateResult = await grain.Get();
+            updateResult.Name.ShouldBe(updateDto.Name);
+            await Task.Delay(500);
+            UsingDbContext(dbContext =>
+            {
+                dbContext.Set<WorkflowForm>().Any(x => x.Id == id).ShouldBeTrue();
+                var workflowForm = dbContext.Set<WorkflowForm>().First(x => x.Id == id);
+                workflowForm.Name.ShouldBe(updateDto.Name);
+            });
+
+            // Delete
+            await grain.Delete();
+            await grain.Over();
+            var deleteResult = await grain.Get();
+            deleteResult.Id.ShouldBe(default);
+            await Task.Delay(500);
+            UsingDbContext(dbContext =>
+            {
+                dbContext.Set<WorkflowForm>().Any(x => x.Id == id).ShouldBeFalse();
             });
         }
     }


### PR DESCRIPTION
Add a new unit test method `CanCreateReadUpdateDelete` to `CrudGrainTests.cs` to test the complete CRUD cycle for `IWorkflowFormGrain<WorkflowFormDto>`.

* Verify the database state after each operation using `UsingDbContext` method.
* Cover Create, Read, Update, and Delete operations in the new test method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/feijie999/RayWorkflow?shareId=6f307d8c-3434-416f-a245-1e2d0b4d14ad).